### PR TITLE
chore: set .nvmrc (lts/fermium)

### DIFF
--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,1 @@
-v13.14.0
+lts/fermium


### PR DESCRIPTION
Zmienia `.nvmrc` na codename `lts/fermium`.

konwersja z 'v13.14.0' -> codename.

Dzięki temu `nvm use` automatycznie dobiera właściwą linię Node dla repo.